### PR TITLE
Add GitHub Actions and NPM badges to readme

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -2,6 +2,10 @@
 <html>
   <header>
     <script type="module" src="../dist/wasm-linker.js"></script>
+    <!-- <script
+      type="module"
+      src="https://unpkg.com/@deislabs/wasm-linker-js/dist/wasm-linker.js"
+    ></script> -->
   </header>
   <body>
     <script type="module" language="javascript" type="text/javascript">

--- a/examples/wasi-example.js
+++ b/examples/wasi-example.js
@@ -1,7 +1,6 @@
 "use strict";
 const { WASI } = require("wasi");
 const { Linker } = require("../dist/src/index");
-const assert = require("assert");
 const fs = require("fs");
 const wasi = new WASI();
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,8 @@
-# A simple WebAssembly Linker in JavaScript
+# wasm-linker-js
+
+### A simple WebAssembly Linker in JavaScript
+
+![actions badge][actions-badge] [![NPM version][npm-image]][npm]
 
 This is _an experimental_ JavaScript library that helps instantiating
 WebAssembly modules with imports by providing functionality to link JavaScript
@@ -214,3 +218,7 @@ additional questions or comments.
 [browser-demo]: examples/index.html
 [node-examples]: examples/node-example.js
 [linker-tests]: tests/linker.ts
+[npm-image]: https://badge.fury.io/js/%40deislabs%2Fwasm-linker-js.svg
+[npm]: https://www.npmjs.com/package/@deislabs/wasm-linker-js
+[actions-badge]:
+  https://github.com/deislabs/wasm-linker-js/workflows/Build%20and%20Test/badge.svg


### PR DESCRIPTION
This PR adds GitHub Actions and NPM build badges to the project's readme.

(there is also some light cleanup in the examples, and in the readme's title.)