### PR TITLE
Update asycify-wasm version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -447,9 +447,9 @@
       "optional": true
     },
     "asyncify-wasm": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/asyncify-wasm/-/asyncify-wasm-1.1.1.tgz",
-      "integrity": "sha512-3h+2XTir20fmWegvM+I6ZUxvXNKeMHdAezoeyDeghZ3A74tD0hxCC1jYFFs5t/MPZnZAwRDz9OLSVrl06pABgg=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/asyncify-wasm/-/asyncify-wasm-1.1.2.tgz",
+      "integrity": "sha512-KGrv8/ZcxRgnQRTL3IYidpA7cFMtVozIRopd2lw/LgCSUWVtxDg93QQ7ulll9kGpq2Vf/RevGU503dRYXxqF+Q=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -547,6 +547,16 @@
       "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-98.0.0.tgz",
       "integrity": "sha512-8wIRIp+uBCL1XpJA9F+zL9TyEsPOIEIaru2KqEPls+nBHx/y64L1isybaOQ+myzn6QgNpSEYMaSH10gaK4ddJg==",
       "dev": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bluebird": {
       "version": "3.7.2",
@@ -1669,6 +1679,13 @@
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
       "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
       "dev": true
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -2890,6 +2907,13 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
     },
     "nanoid": {
       "version": "3.1.12",
@@ -4494,7 +4518,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dist/wasm-linker.js"
   ],
   "dependencies": {
-    "asyncify-wasm": "^1.1.1"
+    "asyncify-wasm": "^1.1.2"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^6.1.0",

--- a/src/@types/asyncify-wasm/index.d.ts
+++ b/src/@types/asyncify-wasm/index.d.ts
@@ -1,4 +1,0 @@
-export class Instance extends WebAssembly.Instance {}
-
-export const instantiate: typeof WebAssembly.instantiate;
-export const instantiateStreaming: typeof WebAssembly.instantiateStreaming;


### PR DESCRIPTION
This commit bumps asycify-wasm to 1.1.2, which now includes type
definitions, meaning we can remove them from this project.
